### PR TITLE
update YSA, YSO and Allärs configuration to match current setup

### DIFF
--- a/bin/allars.config
+++ b/bin/allars.config
@@ -1,0 +1,10 @@
+DATASET=allars
+BASEDIR=/data/skos-history-data/allars/
+FILENAME=allars-skos.ttl
+VERSIONS=($(cd $BASEDIR && find * -maxdepth 0 -type d))
+SCHEMEURI='http://www.yso.fi/onto/allars/'
+
+ENDPOINT=http://sparql.dev.finto.fi/skos-history
+PUT_URI=$ENDPOINT/data
+UPDATE_URI=$ENDPOINT/update
+QUERY_URI=$ENDPOINT/sparql

--- a/bin/load_versions.sh
+++ b/bin/load_versions.sh
@@ -106,7 +106,11 @@ where {
   GRAPH <$BASEURI/$version> {
     # compute identifier (fix missing if necessary)
     # stw and recent thesoz version property
-    OPTIONAL { <$SCHEMEURI> owl:versionInfo ?identifier } .
+    OPTIONAL {
+      <$SCHEMEURI> owl:versionInfo ?identifier
+      # avoid using SVN-generated version strings in e.g. old YSA versions
+      FILTER (!CONTAINS(?identifier, '$'))
+    } .
     # old thesoz version prpoperty
     OPTIONAL { <$SCHEMEURI> dcterms:hasVersion ?identifier } .
     # otherwise, use $version

--- a/bin/ysa.config
+++ b/bin/ysa.config
@@ -1,0 +1,10 @@
+DATASET=ysa
+BASEDIR=/data/skos-history-data/ysa/
+FILENAME=ysa-skos.ttl
+VERSIONS=($(cd $BASEDIR && find * -maxdepth 0 -type d))
+SCHEMEURI='http://www.yso.fi/onto/ysa/'
+
+ENDPOINT=http://sparql.dev.finto.fi/skos-history
+PUT_URI=$ENDPOINT/data
+UPDATE_URI=$ENDPOINT/update
+QUERY_URI=$ENDPOINT/sparql

--- a/bin/yso.config
+++ b/bin/yso.config
@@ -1,6 +1,6 @@
 DATASET=yso
 BASEDIR=/home/sinpessa/tunk/skos-history-yso
-FILENAME=yso.nt
+FILENAME=yso-skos.ttl
 VERSIONS=(20150102 20150128 20150129)
 SCHEMEURI='http://www.yso.fi/onto/yso/'
 


### PR DESCRIPTION
This PR syncs our local edits to the skos-history configuration files. We'd like to keep our fork close to upstream to ensure smooth development processes.

Also there is a small change to load_versions.sh. We had a problem with old YSA versions which have owl:versionInfo strings autogenerated by svn, e.g. `$Id: ysa-skos.ttl 696 2014-04-09 01:24:11Z onkidata $`. These ended up as version numbers but they are really cumbersome and we prefer to use just date strings. The added FILTER expression checks for a dollar sign and thus ensures that such strings don't get used as version identifiers. I think STW and TheSoz should be unaffected since their version numbers don't contain "$".