### PR TITLE
addressing #26 (incorrect count queries)

### DIFF
--- a/sparql/count_added_concepts.rq
+++ b/sparql/count_added_concepts.rq
@@ -9,7 +9,10 @@ PREFIX xhv: <http://www.w3.org/1999/xhtml/vocab#>
 #
 # count concepts inserted per version
 #
-SELECT ?version (str(count(distinct ?concept)) as ?addedConceptCount)
+# note: for the STW, results differ from the STW-specific queries,
+#       cf. Issue #26 (Incorrect results in standard count queries)
+#
+SELECT ?version ?oldVersion (str(count(distinct ?concept)) as ?addedConceptCount)
 WHERE {
   # parameters
   VALUES ( ?versionHistoryGraph ) {
@@ -19,6 +22,7 @@ WHERE {
   GRAPH ?versionHistoryGraph {
     ?delta a sh:SchemeDelta ;
       sh:deltaTo/dc:identifier ?version ;
+      sh:deltaFrom/dc:identifier ?oldVersion ;
       sh:deltaFrom/sh:usingNamedGraph/sd:name ?oldVersionGraph ;
       dcterms:hasPart ?insertions ;
       dcterms:hasPart ?deletions .
@@ -38,5 +42,5 @@ WHERE {
     }
   }
 }
-GROUP BY ?version
-ORDER BY ?version
+GROUP BY ?version ?oldVersion
+ORDER BY ?version ?oldVersion


### PR DESCRIPTION
in order to prevent misleading conclusions,
the revised query explicitly names the
old version that addedConceptCount refers to,
and adds a warning that results should be checked,
and that there is an open issue.
this note should be added to the other count queries, too.

1. note: tested only with STW
2. note: still gives results different from stw-specific count queries